### PR TITLE
Create DAMS5 Curation Concerns host

### DIFF
--- a/playbooks/.gitignore
+++ b/playbooks/.gitignore
@@ -1,0 +1,6 @@
+hosts
+roles
+*.retry
+*.log
+.vaultpassword
+.vagrant

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,17 @@
+DAMS 5 Curation Concerns Demo
+=============================
+
+Installs dependencies for Curation Concerns as listed on [Project Hydra Curation Concerns](https://github.com/projecthydra/curation_concerns/#prerequisites).
+
+Steps:
+
+1. `cd playbooks; ./setup.sh`  
+This will install all required roles
+2. `cp hosts-sample hosts`  
+Edit `hosts` to match your environment
+3. `ansible-playbook playbook.yml -K -k`  
+Runs the playbook against the target host.
+
+To use the Vagrant box:
+
+1. `cd playbooks; vagrant up`

--- a/playbooks/Vagrantfile
+++ b/playbooks/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "centos/7"
+  #config.vm.box = "ubuntu/precise64"
+
+  config.vm.provision :ansible do |ansible|
+     ansible.playbook = "playbook.yml"
+     ansible.groups = {
+        "dams5-cc" => ["default"]
+     }
+     ansible.extra_vars = {
+        do_update: true
+     }
+  end
+end

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+inventory = hosts
+log_path = /tmp/ansible-dams5-cc-pilot.log
+retry_files_save_path = .
+vault_password_file = .vaultpassword
+roles_path=roles

--- a/playbooks/config/roles.yml
+++ b/playbooks/config/roles.yml
@@ -1,0 +1,10 @@
+---
+
+- ucsdlib.fedora-commons
+- ucsdlib.ffmpeg
+- ucsdlib.fits
+- ucsdlib.imagemagick-jpeg2000
+- ucsdlib.libreoffice
+- ucsdlib.postgresql
+- ucsdlib.redis
+- ucsdlib.solr

--- a/playbooks/hosts-sample
+++ b/playbooks/hosts-sample
@@ -1,0 +1,2 @@
+[dams5-cc]
+default

--- a/playbooks/playbook.yml
+++ b/playbooks/playbook.yml
@@ -1,0 +1,28 @@
+---
+
+- hosts: dams5-cc
+  become: true
+
+  vars:
+    - do_update: false
+
+  roles:
+    - ucsdlib.fedora-commons
+    # TODO: write start script for Fedora Commons
+    - { role: 'ucsdlib.ffmpeg', ffmpeg_version: 'release' }
+    - ucsdlib.fits
+    - ucsdlib.imagemagick-jpeg2000
+    # TODO: Determine if RHEL 7 ImageMagick is sufficient
+    - ucsdlib.libreoffice
+    - ucsdlib.postgresql
+    - ucsdlib.redis
+    - ucsdlib.solr
+
+  pre_tasks:
+    - name: Update Packages
+      package:
+        name: '*'
+        state: latest
+      when: do_update
+
+# TODO: setup postgresql databases and users

--- a/playbooks/setup.sh
+++ b/playbooks/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd $(dirname "$0")
+
+echo 'Installing required Ansible roles... '
+
+ansible-galaxy install --role-file=config/roles.yml --roles-path=roles


### PR DESCRIPTION
This playbook / helper files download the roles and runs the playbook to create either a local vagrant or the VM for the DAMS5 CC demo.

It merely installs the dependencies - things like database users or the actual curation concerns are currently absent.